### PR TITLE
logdir and tdbcreate

### DIFF
--- a/lib/metarelate/config.py
+++ b/lib/metarelate/config.py
@@ -126,8 +126,14 @@ def update(config):
                        'Jena triple store database.')
                 raise ValueError(msg.format(env_var))
             else:
-                config[option] = result
-
+                if not os.path.exists(result):
+                    os.mkdir(result)
+                config['tdb_dir'] = os.path.join(result, 'tdb')
+                config['log_dir'] = os.path.join(result, 'logs')
+                if not os.path.exists(config['tdb_dir']):
+                    os.mkdir(config['tdb_dir'])
+                if not os.path.exists(config['log_dir']):
+                    os.mkdir(config['log_dir'])
             option = 'test_static_dir'
             result = _get_dir_option(parser, _SECTION_RESOURCE, option)
             if result is None:

--- a/lib/metarelate/fuseki.py
+++ b/lib/metarelate/fuseki.py
@@ -105,9 +105,10 @@ class FusekiServer(object):
         
         """
         if not self.alive():
-            nohup_dir = metarelate.site_config['root_dir']
-            if self.test:
-                nohup_dir = metarelate.site_config['test_dir']
+            nohup_dir = metarelate.site_config['log_dir']
+            if self.test and \
+                os.access(metarelate.site_config['test_dir'], os.W_OK):
+                    nohup_dir = metarelate.site_config['test_dir']
             nohup_file = os.path.join(nohup_dir, 'nohup.out')
             if os.path.exists(nohup_file):
                 os.remove(nohup_file)


### PR DESCRIPTION
fixed up paths for site installation, enabling sharing of library
